### PR TITLE
Split A/B Test: Return all possible cache keys

### DIFF
--- a/lib/split_cacheable.rb
+++ b/lib/split_cacheable.rb
@@ -67,7 +67,7 @@ module Split
             # Use this to clear all your action_caches
             def get_all_possible_variations
                 test_variations = Array.new
-                active_tests.each { |test_obj|  
+                active_tests.each { |test_obj|
                     split_test = Split::ExperimentCatalog.find(test_obj[:test_name])
                     if split_test
                         test_variations << split_test.alternatives.map { |alternative|
@@ -83,8 +83,12 @@ module Split
                     test_variations[0].unshift(DEFAULT_KEY)
                     return test_variations[0]
                 else
-                    first_test = test_variations.shift
-                    all_variations = first_test.product(*test_variations).map{|a| a.join("/")}
+                    all_variations = []
+                    test_variations.each.with_index(1) do |value, index|
+                        test_variations.combination(index).each do |set|
+                            all_variations += set.first.product(*set[1..-1]).map{|a| a.join("/")}
+                        end
+                    end
                     all_variations.unshift(DEFAULT_KEY)
                     return all_variations
                 end

--- a/spec/cacheable_spec.rb
+++ b/spec/cacheable_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Split::Cacheable do
-    ALL_VARIATIONS = [Split::Cacheable::Adapter::DEFAULT_KEY, "test_1/old/test_2/left", "test_1/old/test_2/right", "test_1/new/test_2/left", "test_1/new/test_2/right"]
+    ALL_VARIATIONS = [Split::Cacheable::Adapter::DEFAULT_KEY, "test_1/old", "test_1/new", "test_2/left", "test_2/right", "test_1/old/test_2/left", "test_1/old/test_2/right", "test_1/new/test_2/left", "test_1/new/test_2/right"]
 
     it "should return the default variation if there is no request" do
         expect(Split::Cacheable::Adapter.new(TestControllerWithoutRequest.new, :index).get_current_variations).to eql Split::Cacheable::Adapter::DEFAULT_KEY
@@ -34,6 +34,10 @@ describe Split::Cacheable do
 
         it "should return one test plus the default key when there is one test" do
             expect(Split::Cacheable::Adapter.new(TestControllerWithOneVariation.new, :index).get_all_possible_variations).to eql [Split::Cacheable::Adapter::DEFAULT_KEY, "test_1/old", "test_1/new"]
+        end
+
+        it "should return all possible variations of the cachekey when controller has multiple tests on same action" do
+            expect(Split::Cacheable::Adapter.new(TestControllerWithRequestAndMultiTestOnSameAction.new, :index).get_all_possible_variations).to eql ALL_VARIATIONS
         end
     end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -81,3 +81,8 @@ class TestControllerWithRequestAndProc < TestControllerWithRequest
         @is_mobile
     end
 end
+
+class TestControllerWithRequestAndMultiTestOnSameAction < TestControllerWithRequest
+    cacheable_ab_test :test_1, :only => :index
+    cacheable_ab_test :test_2, :only => :index
+end

--- a/split_cacheable.gemspec
+++ b/split_cacheable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "split", ">=  0.7.1"
+  spec.add_dependency "split", "~> 1.0.0"
   spec.add_dependency "activesupport", ">= 3.2.17"
 
   spec.add_development_dependency "rspec", ">= 2.14"


### PR DESCRIPTION
* Modify `get_all_possible_variations` to return all possible permutations of a/b test variations